### PR TITLE
Fixes #52 : enable card deletion even if delayed

### DIFF
--- a/back/app/models/card.js
+++ b/back/app/models/card.js
@@ -105,7 +105,7 @@ class Card {
     try {
       const statusCard = await db.query('SELECT is_card_owner($1, $2)', [this.id, this.userId])
       if (!statusCard.rows[0].is_card_owner) {
-        throw new Error('User is not allowed to delete this card')
+        throw new Error(`User #${this.userId} is not allowed to delete card #${this.id}`)
       }
       const { rows } = await db.query('DELETE FROM card WHERE id=$1', [this.id])
       if (rows) {

--- a/back/migrations/deploy/deleteOnCascadeDelay.sql
+++ b/back/migrations/deploy/deleteOnCascadeDelay.sql
@@ -1,0 +1,19 @@
+-- Deploy memoria:deleteOnCascadeDelay to pg
+
+BEGIN;
+
+ALTER TABLE "delay"
+    DROP CONSTRAINT delay_card_id_fkey;
+	
+ALTER TABLE "delay"
+    DROP CONSTRAINT delay_user_id_fkey;
+	
+ALTER TABLE "delay"
+    ADD CONSTRAINT delay_card_id_fkey FOREIGN KEY ("card_id") 
+        REFERENCES "card"(id) ON DELETE CASCADE;
+		
+ALTER TABLE "delay"
+    ADD CONSTRAINT delay_user_id_fkey FOREIGN KEY ("user_id")
+        REFERENCES "user"(id) ON DELETE CASCADE;
+        
+COMMIT;

--- a/back/migrations/revert/deleteOnCascadeDelay.sql
+++ b/back/migrations/revert/deleteOnCascadeDelay.sql
@@ -1,0 +1,19 @@
+-- Revert memoria:deleteOnCascadeDelay from pg
+
+BEGIN;
+
+ALTER TABLE "delay"
+    DROP CONSTRAINT delay_card_id_fkey;
+
+ALTER TABLE "delay"
+    ADD CONSTRAINT delay_card_id_fkey FOREIGN KEY ("card_id") 
+        REFERENCES "card"(id);
+
+ALTER TABLE "delay"
+    DROP CONSTRAINT delay_user_id_fkey;
+
+ALTER TABLE "delay"
+    ADD CONSTRAINT delay_user_id_fkey FOREIGN KEY ("user_id")
+        REFERENCES "user"(id);
+
+COMMIT;

--- a/back/migrations/sqitch.plan
+++ b/back/migrations/sqitch.plan
@@ -9,3 +9,4 @@ user_functions 2021-09-30T13:07:47Z vmingam <vmingam@gmail.com> # Ajout des fonc
 func-getOwnerIdOfCard 2021-09-30T13:21:12Z vmingam <vmingam@gmail.com> # Add function to get the id of owner of a specific card id
 func-cards-save 2021-10-03T19:17:24Z vmingam <vmingam@gmail.com> # Add function to manage and control cards saving
 func-decksOfUser 2021-10-05T11:33:39Z vmingam <vmingam@gmail.com> # Add sql function decks_of_user()
+deleteOnCascadeDelay 2021-11-08T13:08:52Z Vincent Mingam,,, <vincent@vincent-Mint> # Enable deleting card even if associated to a delay

--- a/back/migrations/verify/deleteOnCascadeDelay.sql
+++ b/back/migrations/verify/deleteOnCascadeDelay.sql
@@ -1,0 +1,7 @@
+-- Verify memoria:deleteOnCascadeDelay on pg
+
+BEGIN;
+
+SELECT * FROM "delay" WHERE false;
+
+ROLLBACK;


### PR DESCRIPTION
Heroku DB sqitch migration has already been deployed. 
PR addressed to @JMJHautier only to prevent issue due to the change of error message when user is not allowed to delete this card.